### PR TITLE
Fix issue #2 for bad ruin_entryways_to_other_levels roll

### DIFF
--- a/cmd/dmroll/main.go
+++ b/cmd/dmroll/main.go
@@ -241,10 +241,26 @@ func buildRuin() string {
             numEntryways, _ := dice.RollDice("1d2")
             for i := 0; i < numEntryways; i++ {
                 entryway, _ := tables.RollOnTable("ruin_entryways_to_other_levels")
-                safeguard, _ := tables.RollOnTable("ruin_safeguards_for_entryways")
-                sb.WriteString(fmt.Sprintf("  %s\n", entryway))
-                sb.WriteString(fmt.Sprintf("  %s\n", safeguard))
+                // Check if the entryway roll is the special case
+                if strings.Contains(entryway, "Roll twice") {
+                    // Roll two extra entryways and a safeguard for each
+                    extra1, _ := tables.RollOnTable("ruin_entryways_to_other_levels")
+                    safeguard1, _ := tables.RollOnTable("ruin_safeguards_for_entryways")
+                    sb.WriteString(fmt.Sprintf("  %s\n", extra1))
+                    sb.WriteString(fmt.Sprintf("  %s\n", safeguard1))
+                    
+                    extra2, _ := tables.RollOnTable("ruin_entryways_to_other_levels")
+                    safeguard2, _ := tables.RollOnTable("ruin_safeguards_for_entryways")
+                    sb.WriteString(fmt.Sprintf("  %s\n", extra2))
+                    sb.WriteString(fmt.Sprintf("  %s\n", safeguard2))
+                } else {
+                    // Normal entryway with its safeguard
+                    sb.WriteString(fmt.Sprintf("  %s\n", entryway))
+                    safeguard, _ := tables.RollOnTable("ruin_safeguards_for_entryways")
+                    sb.WriteString(fmt.Sprintf("  %s\n", safeguard))
+                }
             }
+
             sb.WriteString("\n")
         }
     }


### PR DESCRIPTION
- The dmroll -b ruin would sometimes produce a level transition entryway with the result of 8: roll twice, ignoring further results of 8 -- this was unintended behavior that normally isn't an issue when a user is rolling on that table only.
- Updated the for loop in the buildRuin() function on main.go to catch the 'roll twice' result, and roll twice, ignoring further results of 8, and including the two new results plus an additional Safeguard to the output.
- To be honest, I wonder if I misread the engine in the GG - it was my understanding that there could be 1d2 entryways between levels, but we are essentially rolling a 1d2 to assertain the number of entryways plus, if either rolls an 8, two more will be created, potentially leading to four entryways... Not a huge deal, just more dungeon to explore I guess!